### PR TITLE
Fix bill : null value at response

### DIFF
--- a/src/main/java/com/tungstun/barapi/domain/payment/Order.java
+++ b/src/main/java/com/tungstun/barapi/domain/payment/Order.java
@@ -1,6 +1,7 @@
 package com.tungstun.barapi.domain.payment;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.tungstun.barapi.domain.person.Person;
 import com.tungstun.barapi.domain.product.Product;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIdentityInfo(
         generator = ObjectIdGenerators.PropertyGenerator.class,
         property = "id"


### PR DESCRIPTION
Fixed issue where bill response has orders in it's response which contain non removed `bill : null` references